### PR TITLE
Fix for the compilation error at the line 137

### DIFF
--- a/src/main/java/org/gluu/oxd/sample/bean/OxdConfig.java
+++ b/src/main/java/org/gluu/oxd/sample/bean/OxdConfig.java
@@ -134,7 +134,8 @@ public class OxdConfig {
             Properties props = new Properties();
             try {
                 props.load(Files.newInputStream(path));
-                BeanUtils.populate(this, props);
+                Map<String,String> mapprops = (Map)props;
+	            BeanUtils.populate(this, mapprops);
                 fileParsed = true;
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);


### PR DESCRIPTION
I got a compilation error at the line 137 'BeanUtils.populate(this, props);'.
I fixed it by converting Properties into Map and passing it as an argument to BeanUtils.populate method.

Current version (when running 'mvn jetty:run' I am getting a compilation error):
	props.load(Files.newInputStream(path));
	BeanUtils.populate(this, props);

Fix that worked for me (the server has started):
	props.load(Files.newInputStream(path));
	Map<String,String> mapprops = (Map)props;
	BeanUtils.populate(this, mapprops);